### PR TITLE
testing mode for writing mails to a file instead of sending them

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@ Add mailgun to your `mix.exs` dependencies:
     [ {:mailgun, "~> 0.0.1"} ]
   end
   ```
+
+### Test mode
+For testing purposes mailgun can output emails to a local file instead of
+actually sending them. Just set the `mode` configuration key to `:test`
+and the `test_file_path` to where you want that file to appear.
+
+# lib/mailer.ex
+defmodule MyApp.Mailer do
+  use Mailgun.Client, domain: Application.get_env(:my_app, :mailgun_domain),
+                      key: Application.get_env(:my_app, :mailgun_key),
+                      mode: :test,
+                      test_file_path: "/tmp/mailgun.json"
+
+...
+end

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -17,6 +17,13 @@ defmodule Mailgun.Client do
   end
 
   def send_email(conf, email) do
+    do_send_email(conf[:mode], conf, email)
+  end
+  defp do_send_email(:test, conf, email) do
+    log_email(conf, email)
+    {:ok, "OK"}
+  end
+  defp do_send_email(_, conf, email) do
     case email[:attachments] do
       atts when atts in [nil, []] -> send_without_attachments(conf, email)
       atts when is_list(atts)     -> send_with_attachments(conf, email, atts)
@@ -59,6 +66,12 @@ defmodule Mailgun.Client do
     headers = [{'Content-Length', :erlang.integer_to_list(:erlang.length(attachments))}]
 
     request(:post, url("/messages", conf[:domain]), "api", conf[:key], headers, ctype, body)
+  end
+  def log_email(conf, email) do
+    json = email
+    |> Enum.into(%{})
+    |> Poison.encode!
+    File.write(conf[:test_file_path], json)
   end
 
   defp format_multipart_formdata(boundary, fields, files) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,6 +33,8 @@ defmodule Mailgun.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:exvcr, "~> 0.3.3", only: [:test]}]
+    [{:exvcr, "~> 0.4.0", only: [:test]},
+     {:poison, "~> 1.3.1"}
+    ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,11 @@
-%{"exactor": {:hex, :exactor, "0.7.0"},
-  "exvcr": {:hex, :exvcr, "0.3.3"},
-  "hackney": {:hex, :hackney, "0.14.3"},
-  "httpoison": {:hex, :httpoison, "0.5.0"},
-  "idna": {:hex, :idna, "1.0.1"},
+%{"exactor": {:hex, :exactor, "2.0.1"},
+  "exjsx": {:hex, :exjsx, "3.1.0"},
+  "exvcr": {:hex, :exvcr, "0.4.0"},
+  "hackney": {:hex, :hackney, "1.0.6"},
+  "httpoison": {:hex, :httpoison, "0.6.2"},
+  "idna": {:hex, :idna, "1.0.2"},
   "jsex": {:hex, :jsex, "2.0.0"},
-  "jsx": {:hex, :jsx, "2.1.1"},
-  "meck": {:hex, :meck, "0.8.2"}}
+  "jsx": {:hex, :jsx, "2.4.0"},
+  "meck": {:hex, :meck, "0.8.2"},
+  "poison": {:hex, :poison, "1.3.1"},
+  "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"}}

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -58,4 +58,17 @@ defmodule MailgunTest do
     end
   end
 
+  test "sending in test mode writes the mail fields to a file" do
+    file_path = "/tmp/mailgun.json"
+    config = [domain: "mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
+    {:ok, _} = Mailgun.Client.send_email config,
+      to: "foo@bar.test",
+      from: "foo@bar.test",
+      subject: "hello!",
+      text: "How goes it?"
+
+    file_contents = File.read!(file_path)
+    assert file_contents == "{\"to\":\"foo@bar.test\",\"text\":\"How goes it?\",\"subject\":\"hello!\",\"from\":\"foo@bar.test\"}"
+  end
+
 end


### PR DESCRIPTION
I added an option for mailgun to output mails to a local file instead of actually sending them. I use that for integration testing a single page app, where the tests are run by another process.