### PR TITLE
Change to config method for api

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 ```elixir
 # config/config.exs
 
-config :my_app, mailgun_domain: "foo@bar.com",
-                mailgun_key: System.get_env("MAILGUN_KEY")
+config :my_app, mailgun_domain: "https://api.mailgun.net/v3/mydomain.com",
+                mailgun_key: "key-##############"
 
 
 # lib/mailer.ex
@@ -15,16 +15,23 @@ defmodule MyApp.Mailer do
 
   @from "info@example.com"
 
-  def send_welcome_email(user) do
+  def send_welcome_text_email(user) do
     send_email to: user.email,
                from: @from,
                subject: "hello!",
-               body: "Welcome!"
+               text: "Welcome!"
+  end
+
+  def send_welcome_html_email(user) do
+    send_email to: user.email,
+               from: @from,
+               subject: "hello!",
+               html: "<strong>Welcome!</strong>"
   end
 end
 
 
-iex> MyApp.Mailer.send_welcome_email(user)
+iex> MyApp.Mailer.send_welcome_text_email(user)
 {:ok, ...}
 ```
 

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -1,7 +1,5 @@
 defmodule Mailgun.Client do
 
-  @base_url "https://api.mailgun.net/v2/"
-
   defmacro __using__(config) do
     quote do
       def conf, do: unquote(config)
@@ -104,7 +102,7 @@ defmodule Mailgun.Client do
     :string.join(parts, '\r\n')
   end
 
-  def url(path, domain), do: Path.join([@base_url, domain, path])
+  def url(path, domain), do: Path.join([domain, path])
 
   def request(method, url, user, pass, headers, ctype, body) do
     url     = String.to_char_list(url)

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -10,13 +10,13 @@ defmodule MailgunTest do
   end
 
   test "url returns the full url joined with the path and domain config" do
-    assert Mailgun.Client.url("/messages", "mydomain.com") ==
-      "https://api.mailgun.net/v2/mydomain.com/messages"
+    assert Mailgun.Client.url("/messages", "https://api.mailgun.net/v3/mydomain.com") ==
+      "https://api.mailgun.net/v3/mydomain.com/messages"
   end
 
   test "mailers can use Client for configuration automation" do
     defmodule Mailer do
-      use Mailgun.Client, domain: "mydomain.test", key: "my-key"
+      use Mailgun.Client, domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"
     end
 
     assert Mailer.__info__(:functions) |> Enum.member?({:send_email, 1})
@@ -24,8 +24,8 @@ defmodule MailgunTest do
   end
 
   test "send_email returns {:ok, response} if sent successfully" do
-    config = [domain: "mydomain.test", key: "my-key"]
-    use_cassette :stub, [url: "https://api.mailgun.net/v2/mydomain.test/messages",
+    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
+    use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",
                          method: "post",
                          status_code: ["HTTP/1.1", 200, "OK"],
                          body: @success_json] do
@@ -41,8 +41,8 @@ defmodule MailgunTest do
   end
 
   test "send_email returns {:error, reason} if send failed" do
-    config = [domain: "mydomain.test", key: "my-key"]
-    use_cassette :stub, [url: "https://api.mailgun.net/v2/mydomain.test/messages",
+    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
+    use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",
                          method: "post",
                          status_code: ["HTTP/1.1", 400, "BAD REQUEST"],
                          body: @error_json] do
@@ -60,7 +60,7 @@ defmodule MailgunTest do
 
   test "sending in test mode writes the mail fields to a file" do
     file_path = "/tmp/mailgun.json"
-    config = [domain: "mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
+    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
     {:ok, _} = Mailgun.Client.send_email config,
       to: "foo@bar.test",
       from: "foo@bar.test",


### PR DESCRIPTION
Simpler to get started, api + key from mailgun is put directly in config.exs.  Also updated for V3 api, and future api versions since full path is config param.