### PR TITLE
Ensure :ssl is added to applications so it is available in releases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule Mailgun.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :inets]]
+    [applications: [:logger, :inets, :ssl]]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
Ran into this one today when helping someone with a release issue. They were getting the following error when sending mail:

```
Request: POST /api/v1/users
** (exit) an exception was raised:
    ** (MatchError) no match of right hand side value: {:error, :bad_fetch, {:failed_connect, [{:to_address, {'api.mailgun.net', 443}}, {:inet, [:inet], {:eoptions, {:undef, [{:ssl, :connect, ['api.mailgun.net', 443, [:binary, {:active, false}, {:ssl_imp, :new}, :inet], :infinity], []}, {:http_transport, :connect, 4, [file: 'http_transport.erl', line: 134]}, {:httpc_handler, :connect, 4, [file: 'httpc_handler.erl', line: 889]}, {:httpc_handler, :connect_and_send_first_request, 3, [file: 'httpc_handler.erl', line: 903]}, {:httpc_handler, :init, 1, [file: 'httpc_handler.erl', line: 241]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 237]}]}}}]}}
        (phoenix_token_auth) lib/phoenix_token_auth/mailer.ex:33: PhoenixTokenAuth.Mailer.send_welcome_email/2
        (ecto) lib/ecto/adapters/sql.ex:442: Ecto.Adapters.SQL.transaction/3
        (phoenix_token_auth) lib/phoenix_token_auth/users_controller.ex:29: PhoenixTokenAuth.UsersController.create/2
        (phoenix_token_auth) lib/phoenix_token_auth/users_controller.ex:1: PhoenixTokenAuth.UsersController.phoenix_controller_pipeline/2
        (echo) lib/phoenix/router.ex:297: Echo.Router.dispatch/2
        (echo) lib/phoenix/router.ex:2: Echo.Router.call/2
        (echo) lib/echo/endpoint.ex:1: Echo.Endpoint.phoenix_endpoint_pipeline/1
        (echo) lib/phoenix/endpoint/render_errors.ex:34: Echo.Endpoint.call/2
```

Turns out the reason was that they didn't have `:ssl` in their applications list, but since it's a dependency of mailer specifically (and in fact requires that it is there due to the call to `ensure_started :ssl`), it seems this should be added alongside `:inets`.

/cc @schainker