### PR TITLE
fix(Mailgun.Client): prevent __using__ from changing context

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -2,7 +2,8 @@ defmodule Mailgun.Client do
 
   defmacro __using__(config) do
     quote do
-      def conf, do: unquote(config)
+      @conf unquote(config)
+      def conf, do: @conf
       def send_email(email) do
         unquote(__MODULE__).send_email(conf(), email)
       end


### PR DESCRIPTION
When doing something like:

    defmodule MyApp.Mailer do
      defmacro __using__(_opts) do
        quote do
          config = Application.get_env(:my_app, MyApp.Mailer)
          use Mailgun.Client,
            domain: config[:mailgun_domain],
            key: config[:mailgun_key],
            mode: config[:mode],
            test_file_path: config[:test_file_path]

          @from "noreply@myapp.io"
        end
      end
    end

An error is raised :

 > Compilation error on file welcome_mailer.ex ==
 > (CompileError) welcome_mailer.ex:2: function config/0 undefined
 >  (stdlib) lists.erl:1336: :lists.foreach/2
 >  (stdlib) erl_eval.erl:657: :erl_eval.do_apply/6

The context is now preserved to allow the client to be wrapped.

This closes #14