### PR TITLE
Relax poison dependency to ~> 1.4

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Mailgun.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:exvcr, "~> 0.4.0", only: [:test]},
-     {:poison, "~> 1.4.0"}
+     {:poison, "~> 1.4"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -7,5 +7,5 @@
   "jsex": {:hex, :jsex, "2.0.0"},
   "jsx": {:hex, :jsx, "2.4.0"},
   "meck": {:hex, :meck, "0.8.2"},
-  "poison": {:hex, :poison, "1.4.0"},
+  "poison": {:hex, :poison, "1.5.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.1"}}


### PR DESCRIPTION
I don't think such a strict dependency is required for this project, given semantic versioning. This will also limit "poison update" commits in the future.