### PR TITLE
Remove superfluous config macro

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -1,6 +1,6 @@
 defmodule Mailgun.Client do
 
-  def get_attachment(mailer, url) do
+  def get_attachment(url) do
     request :get, url, "api", conf(:key), [], "", ""
   end
 

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -1,36 +1,25 @@
 defmodule Mailgun.Client do
 
-  defmacro __using__(config) do
-    quote do
-      @conf unquote(config)
-      def conf, do: @conf
-      def send_email(email) do
-        unquote(__MODULE__).send_email(conf(), email)
-      end
-    end
-  end
-
   def get_attachment(mailer, url) do
-    config = mailer.conf
-    request config, :get, url, "api", config[:key], [], "", ""
+    request :get, url, "api", conf(:key), [], "", ""
   end
 
-  def send_email(conf, email) do
-    do_send_email(conf[:mode], conf, email)
+  def send_email(email) do
+    do_send_email(conf(:mode), email)
   end
-  defp do_send_email(:test, conf, email) do
-    log_email(conf, email)
+  defp do_send_email(:test, email) do
+    log_email(email)
     {:ok, "OK"}
   end
-  defp do_send_email(_, conf, email) do
+  defp do_send_email(_, email) do
     case email[:attachments] do
       atts when atts in [nil, []] ->
-        send_without_attachments(conf, email)
+        send_without_attachments(email)
       atts when is_list(atts) ->
-        send_with_attachments(conf, Dict.delete(email, :attachments), atts)
+        send_with_attachments(Dict.delete(email, :attachments), atts)
     end
   end
-  defp send_without_attachments(conf, email) do
+  defp send_without_attachments(email) do
     attrs = Dict.merge(email, %{
       to: Dict.fetch!(email, :to),
       from: Dict.fetch!(email, :from),
@@ -41,9 +30,9 @@ defmodule Mailgun.Client do
     ctype   = 'application/x-www-form-urlencoded'
     body    = URI.encode_query(Dict.drop(attrs, [:attachments]))
 
-    request(conf, :post, url("/messages", conf[:domain]), "api", conf[:key], [], ctype, body)
+    request(:post, url("/messages", conf(:domain)), "api", conf(:key), [], ctype, body)
   end
-  defp send_with_attachments(conf, email, attachments) do
+  defp send_with_attachments(email, attachments) do
     attrs =
       email
       |> Dict.merge(%{
@@ -72,13 +61,13 @@ defmodule Mailgun.Client do
 
     headers = [{'Content-Length', :erlang.integer_to_list(:erlang.length(attachments))} | headers]
 
-    request(conf, :post, url("/messages", conf[:domain]), "api", conf[:key], headers, ctype, body)
+    request(:post, url("/messages", conf(:domain)), "api", conf(:key), headers, ctype, body)
   end
-  def log_email(conf, email) do
+  def log_email(email) do
     json = email
     |> Enum.into(%{})
     |> Poison.encode!
-    File.write(conf[:test_file_path], json)
+    File.write(conf(:test_file_path), json)
   end
 
   defp format_multipart_formdata(boundary, fields, files) do
@@ -105,9 +94,9 @@ defmodule Mailgun.Client do
 
   def url(path, domain), do: Path.join([domain, path])
 
-  def request(conf, method, url, user, pass, headers, ctype, body) do
+  def request(method, url, user, pass, headers, ctype, body) do
     url  = String.to_char_list(url)
-    opts = conf[:httpc_opts] || []
+    opts = conf(:httpc_opts, [])
 
     case method do
       :get ->
@@ -137,4 +126,7 @@ defmodule Mailgun.Client do
       {:error, reason} -> {:error, :bad_fetch, reason}
     end
   end
+
+  defp conf(key),          do: Application.get_env(:mailgun, key)
+  defp conf(key, default), do: Application.get_env(:mailgun, key, default)
 end

--- a/lib/mailgun.ex
+++ b/lib/mailgun.ex
@@ -1,15 +1,10 @@
 defmodule Mailgun do
 
+  @app :mailgun
+
   def start do
-    ensure_started :inets
-    ensure_started :ssl
-    :ok
+    Application.ensure_all_started @app
   end
 
-  defp ensure_started(module) do
-    case module.start do
-      :ok -> :ok
-      {:error, {:already_started, _module}} -> :ok
-    end
   end
 end

--- a/lib/mailgun.ex
+++ b/lib/mailgun.ex
@@ -6,5 +6,9 @@ defmodule Mailgun do
     Application.ensure_all_started @app
   end
 
+  def stop do
+    Application.stop @app
+    Application.unload @app
   end
+
 end

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -17,8 +17,7 @@ defmodule MailgunTest do
   end
 
   test "send_email returns {:ok, response} if sent successfully" do
-    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
-    set_conf config
+    set_conf [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
     use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",
                          method: "post",
                          status_code: ["HTTP/1.1", 200, "OK"],

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -5,8 +5,10 @@ defmodule MailgunTest do
   @success_json "{\n  \"message\": \"Queued. Thank you.\",\n  \"id\": \"<someuser@somedomain.mailgun.org>\"\n}"
   @error_json "{\n  \"message\": \"'to' parameter is not a valid address. please check documentation\"\n}"
 
-  setup_all do
+  setup do
     Mailgun.start
+
+    on_exit &Mailgun.stop/0
   end
 
   test "url returns the full url joined with the path and domain config" do
@@ -14,24 +16,15 @@ defmodule MailgunTest do
       "https://api.mailgun.net/v3/mydomain.com/messages"
   end
 
-  test "mailers can use Client for configuration automation" do
-    defmodule Mailer do
-      use Mailgun.Client, domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"
-    end
-
-    assert Mailer.__info__(:functions) |> Enum.member?({:send_email, 1})
-
-  end
-
   test "send_email returns {:ok, response} if sent successfully" do
     config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
+    set_conf config
     use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",
                          method: "post",
                          status_code: ["HTTP/1.1", 200, "OK"],
                          body: @success_json] do
 
-      {:ok, body} = Mailgun.Client.send_email config,
-                                              to: "foo@bar.test",
+      {:ok, body} = Mailgun.Client.send_email to: "foo@bar.test",
                                               from: "foo@bar.test",
                                               subject: "hello!",
                                               text: "How goes it?"
@@ -41,14 +34,13 @@ defmodule MailgunTest do
   end
 
   test "send_email returns {:error, reason} if send failed" do
-    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
+    set_conf [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
     use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",
                          method: "post",
                          status_code: ["HTTP/1.1", 400, "BAD REQUEST"],
                          body: @error_json] do
 
-      {:error, status, body} = Mailgun.Client.send_email config,
-                                                         to: "foo@bar.test",
+      {:error, status, body} = Mailgun.Client.send_email to: "foo@bar.test",
                                                          from: "foo@bar.test",
                                                          subject: "hello!",
                                                          text: "How goes it?"
@@ -60,15 +52,18 @@ defmodule MailgunTest do
 
   test "sending in test mode writes the mail fields to a file" do
     file_path = "/tmp/mailgun.json"
-    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
-    {:ok, _} = Mailgun.Client.send_email config,
-      to: "foo@bar.test",
-      from: "foo@bar.test",
-      subject: "hello!",
-      text: "How goes it?"
+    set_conf [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
+    {:ok, _} = Mailgun.Client.send_email to: "foo@bar.test",
+                                         from: "foo@bar.test",
+                                         subject: "hello!",
+                                         text: "How goes it?"
 
     file_contents = File.read!(file_path)
     assert file_contents == "{\"to\":\"foo@bar.test\",\"text\":\"How goes it?\",\"subject\":\"hello!\",\"from\":\"foo@bar.test\"}"
+  end
+
+  defp set_conf(config) do
+    config |> Enum.each(fn {k, v} -> Application.put_env(:mailgun, k, v) end)
   end
 
 end


### PR DESCRIPTION
@chrismccord I have removed the config macro. There is nothing wrong with calling `Application.get_env` as much as one needs. This also allows painless deployment on heroku, where the env variables (such as the mailgun API key) are unavailable at compile-time.

I will update the README and bump major version once the code gets green light.
