### PR TITLE
remove ensure_started, add included_applications

### DIFF
--- a/lib/mailgun.ex
+++ b/lib/mailgun.ex
@@ -1,15 +1,8 @@
 defmodule Mailgun do
+  @moduledoc "Elixir Mailgun Client"
 
   def start do
-    ensure_started :inets
-    ensure_started :ssl
+    Application.ensure_all_started(:mailgun)
     :ok
-  end
-
-  defp ensure_started(module) do
-    case module.start do
-      :ok -> :ok
-      {:error, {:already_started, _module}} -> :ok
-    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,25 +2,30 @@ defmodule Mailgun.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :mailgun,
-     version: "0.1.3",
-     elixir: "~> 1.0",
-     deps: deps,
-     package: [
-       contributors: ["Chris McCord"],
-       licenses: ["MIT"],
-       links: %{github: "https://github.com/chrismccord/mailgun"}
-     ],
-     description: """
-     Elixir Mailgun Client
-     """]
+    [
+      app: :mailgun,
+      version: "0.1.3",
+      elixir: "~> 1.0",
+      deps: deps,
+      package: [
+        contributors: ["Chris McCord"],
+        licenses: ["MIT"],
+        links: %{github: "https://github.com/chrismccord/mailgun"}
+      ],
+      description: """
+      Elixir Mailgun Client
+      """
+   ]
   end
 
   # Configuration for the OTP application
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :inets, :ssl]]
+    [
+      applications: [:logger, :inets, :ssl],
+      included_applications: [:poison]
+    ]
   end
 
   # Dependencies can be Hex packages:
@@ -33,8 +38,9 @@ defmodule Mailgun.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [{:exvcr, "~> 0.4.0", only: [:test]},
-     {:poison, "~> 1.4"}
+    [
+      {:exvcr, "~> 0.4.0", only: [:test]},
+      {:poison, "~> 1.4"}
     ]
   end
 end


### PR DESCRIPTION
The application will not be started by BEAM VM if its dependencies
are not started. The best way to start an application that only
provides modules and has no processes is to have `mod:[]` in its
application resource and run `ensure_all_started` to start all
its dependencies.

However, starting this application is not strictly required if its
dependencies have been started. In our case the only dependencies are
from erts and are hence automatically started.

A convinience method `start/0` is still provided
that retains existing functionality by delegating to
`Application.ensure_all_started/2`.

The key `:included_applications` in `mix.exs` enables build tooks such
as exrm to automatically add the listed apps to release and load them.
`:poison` is added here to enable good release handling.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chrismccord/mailgun/25)

<!-- Reviewable:end -->
