### PR TITLE
Enable runtime loading of config

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -7,6 +7,7 @@ defmodule Mailgun.Client do
       def send_email(email) do
         unquote(__MODULE__).send_email(conf(), email)
       end
+      defoverridable [conf: 0]
     end
   end
 


### PR DESCRIPTION
Currently the `__using__` macro expects the config, and the values
are evaluated at compile time and persisted. This does not fit well
with a typical deployment strategy where configuration is injected
through environment variables or config files just before startup.

This change retains backward compatibility and allows any module
`use` ing `Mailgun.Client` to define a function `conf/0` that will
return a keyword list. This function for instance may read the values
from application config. To illustrate,

```elixir
use Mailgun.Client, domain: Application.get_env(:library, :mailgun_domain),
                    key: Application.get_env(:library, :mailgun_key),
                    mode: Application.get_env(:library, :mailgun_mode),
                    test_file_path: Application.get_env(:library, :mailgun_test_file_path)
```

will use the config values present at compile time, but with the change
in this commit, if we instead do

```elixir
use Mailgun.Client

def conf do
  [
    domain: Application.get_env(:library, :mailgun_domain),
    key: Application.get_env(:library, :mailgun_key),
    mode: Application.get_env(:library, :mailgun_mode),
    test_file_path: Application.get_env(:library, :mailgun_test_file_path)
  ]
end
```

the configuration will be read at runtime, which is probably what
everyone using this library wants.

This is in response to discussion at
https://groups.google.com/forum/#!topic/elixir-lang-talk/OzHSkE328Js