### PR TITLE
Add capability of logging multiple emails

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -161,10 +161,17 @@ defmodule Mailgun.Client do
   defp parse_attachment(%{path: path}), do: File.read!(path)
 
   def log_email(conf, email) do
-    json = email
-    |> Enum.into(%{})
-    |> Poison.encode!
+    json = Poison.encode!(parse_log_file(conf) ++ [Enum.into(email, %{})])
     File.write(conf[:test_file_path], json)
+  end
+
+  defp parse_log_file(conf) do
+    case File.read(conf[:test_file_path]) do
+      {:ok, contents} ->
+        Poison.Parser.parse!(contents)
+      {:error, _} ->
+        []
+    end
   end
 
   defp format_multipart_formdata(boundary, fields, files) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Mailgun.Mixfile do
     [app: :mailgun,
      version: "0.1.3",
      elixir: "~> 1.0",
-     deps: deps,
+     deps: deps(),
      package: [
        contributors: ["Chris McCord"],
        licenses: ["MIT"],

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -87,15 +87,22 @@ defmodule MailgunTest do
 
   test "sending in test mode writes the mail fields to a file" do
     file_path = "/tmp/mailgun.json"
+    File.rm file_path
+
     config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
     {:ok, _} = Mailgun.Client.send_email config,
       to: "foo@bar.test",
       from: "foo@bar.test",
       subject: "hello!",
       text: "How goes it?"
+    {:ok, _} = Mailgun.Client.send_email config,
+      to: "foo@bar.test",
+      from: "foo@bar.test",
+      subject: "hello again!",
+      text: "Really!"
 
     file_contents = File.read!(file_path)
-    assert file_contents == "{\"to\":\"foo@bar.test\",\"text\":\"How goes it?\",\"subject\":\"hello!\",\"from\":\"foo@bar.test\"}"
+    assert file_contents == "[{\"to\":\"foo@bar.test\",\"text\":\"How goes it?\",\"subject\":\"hello!\",\"from\":\"foo@bar.test\"},{\"to\":\"foo@bar.test\",\"text\":\"Really!\",\"subject\":\"hello again!\",\"from\":\"foo@bar.test\"}]"
   end
 
 end


### PR DESCRIPTION
Hey, thanks for making this! I’m new to Elixir and Phoenix but enjoying building an application with TDD. I trigger two emails when a person creates an account in the application: one to the new person, and one to the administrator. So the current implementation where the JSON log file is replaced for each email prevents me from testing for both emails.

I realise this is a significant change and would break anyone’s application that relies on the current implementation. I could add another configuration flag to turn on this functionality? I figured I’d start with this possibility and seek your input. I had to add a step to delete the log file if it existed, which is a bit cumbersome.

Also, since I’m so new to the language, I am still learning the idioms; let me know if I’ve written anything in an awkward way.
