### PR TITLE
returns content email in test mode

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -101,8 +101,8 @@ defmodule Mailgun.Client do
     do_send_email(conf[:mode], conf, email)
   end
   defp do_send_email(:test, conf, email) do
-    log_email(conf, email)
-    {:ok, "OK"}
+    body = log_email(conf, email)
+    {:ok, 200, body }
   end
   defp do_send_email(_, conf, email) do
     case email[:attachments] do
@@ -165,6 +165,7 @@ defmodule Mailgun.Client do
     |> Enum.into(%{})
     |> Poison.encode!
     File.write(conf[:test_file_path], json)
+    Poison.decode! json
   end
 
   defp format_multipart_formdata(boundary, fields, files) do

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -88,7 +88,7 @@ defmodule MailgunTest do
   test "sending in test mode writes the mail fields to a file" do
     file_path = "/tmp/mailgun.json"
     config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
-    {:ok, _} = Mailgun.Client.send_email config,
+    {:ok, status, body } = Mailgun.Client.send_email config,
       to: "foo@bar.test",
       from: "foo@bar.test",
       subject: "hello!",
@@ -98,4 +98,16 @@ defmodule MailgunTest do
     assert file_contents == "{\"to\":\"foo@bar.test\",\"text\":\"How goes it?\",\"subject\":\"hello!\",\"from\":\"foo@bar.test\"}"
   end
 
+  test "send_mail returns {:ok, status, json_body} if sent successfully in test mode" do
+    file_path = "/tmp/mailgun.json"
+    config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key", mode: :test, test_file_path: file_path]
+    {:ok, status, json_body} = Mailgun.Client.send_email config,
+      to: "foo@bar.test",
+      from: "foo@bar.test",
+      subject: "hello!",
+      text: "How goes it?"
+
+    assert status == 200
+    assert json_body == %{"from" => "foo@bar.test", "subject" => "hello!", "text" => "How goes it?", "to" => "foo@bar.test"}
+  end
 end


### PR DESCRIPTION
I need to verify the contents(`status`, `to`, `text`...) of the email when run `mix test` and think it's easier if our method directly returns this information.