### PR TITLE
Adding details about how to send to more than one email address

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ defmodule MyApp.Mailer do
                html: "<strong>Welcome!</strong>"
   end
 
+  # Send email to more than one email address (all addresses should be in one single String seperated with commas)
+
+  def send_welcome_html_email(user) do
+    send_email to: "#{user.email_main}, #{user.email_alternative}",
+               from: @from,
+               subject: "hello!",
+               html: "<strong>Welcome!</strong>"
+  end
+
  # attachments expect a list of maps. Each map should have a filename and path/content
 
   def send_greetings(user, file_path) do


### PR DESCRIPTION
As it is not quite obvious how to send a single email to more than one email address, I've added a section to illustrate how to do so in the README file. 
It took me a while to figure that out when I was using the library before.
