### PR TITLE
Allowed for dynamic mailgun configuration

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -84,8 +84,7 @@ defmodule Mailgun.Client do
 
   defmacro __using__(config) do
     quote do
-      @conf unquote(config)
-      def conf, do: @conf
+      def conf, do: unquote(config)
       def send_email(email) do
         unquote(__MODULE__).send_email(conf(), email)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Mailgun.Mixfile do
 
   def project do
     [app: :mailgun,
-     version: "0.1.3",
+     version: "0.1.4",
      elixir: "~> 1.0",
      deps: deps,
      package: [

--- a/test/mailgun_test.exs
+++ b/test/mailgun_test.exs
@@ -23,6 +23,18 @@ defmodule MailgunTest do
 
   end
 
+  test "mailer configuration is load dynamically" do
+    Application.put_env(:mailgun, :domain, "https://api.mailgun.net/v3/domain.test")
+
+    defmodule Mailer do
+      use Mailgun.Client, domain: Application.get_env(:mailgun, :domain), key: "my-key"
+    end
+
+    Application.put_env(:mailgun, :domain, "https://api.mailgun.net/v3/updated_domain.test")
+
+    assert Mailer.conf() == [domain: "https://api.mailgun.net/v3/updated_domain.test", key: "my-key"]
+  end
+
   test "send_email returns {:ok, response} if sent successfully" do
     config = [domain: "https://api.mailgun.net/v3/mydomain.test", key: "my-key"]
     use_cassette :stub, [url: "https://api.mailgun.net/v3/mydomain.test/messages",


### PR DESCRIPTION
This change would allow to use Application config to change settings of mailgun after compilation, as referenced in issue #34. I believe it would be useful, as requiring recompilation for settings change is quite tiresome.
