### PR TITLE
Bump up allowed Poison version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Mailgun.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:exvcr, "~> 0.4.0", only: [:test]},
-     {:poison, "~> 1.4 or ~> 2.0"}
+     {:poison, "~> 1.4 or ~> 2.2"}
     ]
   end
 end


### PR DESCRIPTION
Some Phoenix libraries like Addict are not yet ready for Phoenix 1.2 due to dependency issues. Mailgun is one, since it is not allowing Poison beyond 2.0. When creating new Phoenix 1.2 applications, Poison is being locked at 2.2.0.
