### PR TITLE
Update client.ex

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -186,7 +186,7 @@ defmodule Mailgun.Client do
     ending_parts = [:lists.concat(['--', boundary, '--']), '']
     parts = :lists.append([field_parts2, file_parts2, ending_parts])
 
-    :string.join(parts, '\r\n')
+    :string.join(parts, '\r\n') |> List.to_string()
   end
 
   def url(path, domain), do: Path.join([domain, path])


### PR DESCRIPTION
Fixed issue when we send email with  `illegal` characters inside subject/body.
Those characters made entire payload as a char list which is not possible to post to endpoint
Maybe closes #45 