### PR TITLE
update poison version and getting rid of module attribute

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -84,8 +84,7 @@ defmodule Mailgun.Client do
 
   defmacro __using__(config) do
     quote do
-      @conf unquote(config)
-      def conf, do: @conf
+      def conf, do: unquote(config)
       def send_email(email) do
         unquote(__MODULE__).send_email(conf(), email)
       end

--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Mailgun.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [{:exvcr, "~> 0.4.0", only: [:test]},
-     {:poison, "~> 1.4 or ~> 2.0"}
+     {:poison, "~> 3.0"}
     ]
   end
 end


### PR DESCRIPTION
getting rid of module attribute because you might not have config at compilation time. 